### PR TITLE
Update README with Expo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-codex-app
+# Codex App
+
+A simple content management app built with Expo.
+
+## Getting Started
+
+1. **Install Node.js**
+   - Use the latest LTS version (Node 18+ works well with Expo).
+
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   The repository includes an `.npmrc` file which enables `legacy-peer-deps` for compatibility.
+
+3. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   This executes `npx expo start` with telemetry disabled. Expo Developer Tools will open in your browser.
+
+4. **Open the app**
+   - Scan the QR code with the Expo Go app on your device, **or**
+   - Launch an Android or iOS simulator from Expo Developer Tools.
+
+### Additional Notes
+
+- You can install the Expo CLI globally if you plan to use Expo commands directly:
+  ```bash
+  npm install -g expo-cli
+  ```
+- For iOS development, ensure Xcode is installed. For Android, install Android Studio or use the Expo Go app on a physical device.
+
+### Web Support
+
+From Expo Developer Tools, press `w` to open the web version of the app in your browser.


### PR DESCRIPTION
## Summary
- add instructions to install dependencies and run the dev server
- include notes about Expo environment setup

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_b_6866e5f7152c83209c9f3d7ffa1cf8d4