### PR TITLE
Fix frameworkReady effect to run only on mount

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -9,5 +9,5 @@ declare global {
 export function useFrameworkReady() {
   useEffect(() => {
     window.frameworkReady?.();
-  });
+  }, []);
 }


### PR DESCRIPTION
## Summary
- ensure `window.frameworkReady` only runs on component mount

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866e5f1a2d08320b6e6451c48687437