### PR TITLE
Update Content interface and stats

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -22,7 +22,7 @@ export default function HomeScreen() {
     totalContents: 0,
     publishedContents: 0,
     draftContents: 0,
-    reviewContents: 0,
+    pendingContents: 0,
   });
   const [refreshing, setRefreshing] = useState(false);
 
@@ -61,13 +61,13 @@ export default function HomeScreen() {
       const totalContents = data?.length || 0;
       const publishedContents = data?.filter(c => c.status === 'published').length || 0;
       const draftContents = data?.filter(c => c.status === 'draft').length || 0;
-      const reviewContents = data?.filter(c => c.status === 'review').length || 0;
+      const pendingContents = data?.filter(c => c.status === 'pending_approval').length || 0;
 
       setStats({
         totalContents,
         publishedContents,
         draftContents,
-        reviewContents,
+        pendingContents,
       });
     } catch (error) {
       console.error('Error fetching stats:', error);
@@ -85,10 +85,14 @@ export default function HomeScreen() {
     switch (status) {
       case 'published':
         return '#10B981';
+      case 'approved':
+        return '#10B981';
       case 'draft':
         return '#F59E0B';
-      case 'review':
+      case 'pending_approval':
         return '#8B5CF6';
+      case 'rejected':
+        return '#EF4444';
       default:
         return '#6B7280';
     }
@@ -140,8 +144,8 @@ export default function HomeScreen() {
             </View>
             <View style={styles.statCard}>
               <Users size={24} color="#8B5CF6" />
-              <Text style={styles.statNumber}>{stats.reviewContents}</Text>
-              <Text style={styles.statLabel}>In Review</Text>
+              <Text style={styles.statNumber}>{stats.pendingContents}</Text>
+              <Text style={styles.statLabel}>Pending</Text>
             </View>
           </View>
         </View>

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -6,7 +6,7 @@ export interface AnalyticsData {
   totalContents: number;
   publishedContents: number;
   draftContents: number;
-  reviewContents: number;
+  pendingContents: number;
   totalViews: number;
   avgEngagement: number;
   postsPerDay: { date: string; count: number }[];
@@ -43,7 +43,7 @@ export function useAnalytics() {
       const totalContents = contents?.length || 0;
       const publishedContents = contents?.filter(c => c.status === 'published').length || 0;
       const draftContents = contents?.filter(c => c.status === 'draft').length || 0;
-      const reviewContents = contents?.filter(c => c.status === 'review').length || 0;
+      const pendingContents = contents?.filter(c => c.status === 'pending_approval').length || 0;
       const totalViews = contents?.reduce((sum, c) => sum + (c.view_count || 0), 0) || 0;
       const avgEngagement = contents?.reduce((sum, c) => sum + (c.engagement_score || 0), 0) / totalContents || 0;
 
@@ -68,7 +68,7 @@ export function useAnalytics() {
       const statusDistribution = [
         { status: 'published', count: publishedContents },
         { status: 'draft', count: draftContents },
-        { status: 'review', count: reviewContents },
+        { status: 'pending_approval', count: pendingContents },
       ];
 
       // Top tags
@@ -88,7 +88,7 @@ export function useAnalytics() {
         totalContents,
         publishedContents,
         draftContents,
-        reviewContents,
+        pendingContents,
         totalViews,
         avgEngagement,
         postsPerDay,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -10,9 +10,14 @@ export interface Content {
   user_id: string;
   title: string;
   description: string;
-  type: 'post' | 'story' | 'video';
+  type: 'post' | 'carousel' | 'video' | 'story';
   media: string[];
-  status: 'draft' | 'published' | 'review';
+  tags: string[];
+  status: 'draft' | 'pending_approval' | 'approved' | 'rejected' | 'published';
+  scheduled_at?: string | null;
+  published_at?: string | null;
+  view_count: number;
+  engagement_score: number;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- expand `Content` interface to match new database schema
- handle new content statuses in Home screen
- adapt analytics hook to recognize pending approval status

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866ed905db08320904afefa1a3d9b95