### PR TITLE
Fix status history migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,10 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+module.exports = compat.config({
+  root: true,
+  extends: ['expo'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  env: { browser: true }
+});

--- a/supabase/migrations/20250703214955_shiny_island.sql
+++ b/supabase/migrations/20250703214955_shiny_island.sql
@@ -22,6 +22,13 @@
     - `on_content_status_change` - Automatically log status changes on contents table
 */
 
+-- Clean up any previous implementation
+DROP TRIGGER IF EXISTS contents_initial_status ON public.contents;
+DROP TRIGGER IF EXISTS contents_status_change ON public.contents;
+DROP FUNCTION IF EXISTS record_status_change();
+DROP FUNCTION IF EXISTS calculate_status_time(uuid);
+DROP TABLE IF EXISTS public.content_status_history CASCADE;
+
 -- Tabela para armazenar o histórico de mudanças de status
 CREATE TABLE IF NOT EXISTS public.content_status_history (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary
- clean up previous status history objects before creating table
- add fallback ESLint config for new flat system

## Testing
- `npm run lint` *(fails: Cannot set properties of undefined (setting 'defaultMeta'))*

------
https://chatgpt.com/codex/tasks/task_b_6866fc8f3de8832087a962a97ddecc73